### PR TITLE
Fix branch guard placement and update Jenkins config

### DIFF
--- a/JenkinsfileProd
+++ b/JenkinsfileProd
@@ -1,2 +1,2 @@
 @Library('paves-shared-lib') _ 
-deployToProd(serviceName: 'ums', serviceType: 'python', ecrRepo: 'paves/ums-prod')
+deployToProd(serviceName: 'ums', ecrRepo: 'paves/ums-prod')

--- a/day_wise_changes.md
+++ b/day_wise_changes.md
@@ -33,3 +33,7 @@ testing ci
 updating deploytodev with branch protection
 
 Moved the branch guard inside the pipeline after checkout, so GIT_BRANCH is actually set when the check runs — the previous guard ran before checkout where GIT_BRANCH is always empty, making it silently skip every time.
+
+DATE: 26/06/2026
+
+Updated system configure in manage jenkins (unchecked "Include @Library changes in job recent changes" on both libraries)


### PR DESCRIPTION
Moved branch guard inside pipeline after checkout to ensure GIT_BRANCH is set correctly during checks. Updated Jenkins configuration to exclude library changes in job recent changes.